### PR TITLE
fix: remove unused plugins array from auth configuration

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -23,7 +23,6 @@ export function initAuth(options: {
         clientSecret: env.GITHUB_CLIENT_SECRET,
       },
     },
-    plugins: [],
   } satisfies BetterAuthOptions;
 
   return betterAuth(config);


### PR DESCRIPTION
Usually, this would be a refactor, but it is classified as a fix as having the empty plugins array messes with the inference in the auth session object (i.e. fields that you would expect like user.id cannot be found if the empty plugin declaration is not removed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined authentication configuration by removing an unused plugin setting, simplifying setup and improving maintainability. No changes to behavior or available options.

- **Chores**
  - Cleaned up internal auth config to align with current platform standards. No action required for users; existing logins and integrations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->