### PR TITLE
feat(ci): reinstate-trigger.dev-gh-action

### DIFF
--- a/.github/workflows/release-trigger-prod.yml
+++ b/.github/workflows/release-trigger-prod.yml
@@ -1,0 +1,32 @@
+name: Deploy to Trigger.dev (prod)
+
+on:   
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.1.0
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.19.0
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: 🚀 Deploy Trigger.dev
+        env:
+          TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
+        run: |
+          pnpm deploy:trigger-prod


### PR DESCRIPTION
Apparently, I just needed to add the variables on the Trigger.dev project dashboard to fix what I described in (#30). I'd assumed otherwise since I'd never had to do that in development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated production deployment workflow triggered on pushes to main, standardizing dependency install, caching, and deploy steps using repository secrets.
  * Improves release consistency, reduces manual intervention, and speeds delivery through optimized automation.
  * No user-facing feature changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->