### PR TITLE
chore: setup husky to manage pre-commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+pnpm check:write
+pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "deploy:trigger-prod": "trigger deploy",
     "preview": "next build && next start",
     "start": "next start",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepare": "husky"
   },
   "dependencies": {
     "@better-fetch/fetch": "^1.1.18",
@@ -60,6 +61,7 @@
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "drizzle-kit": "^0.31.4",
+    "husky": "^9.1.7",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.13",
     "trigger.dev": "4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.4
         version: 0.31.4
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -2357,6 +2360,11 @@ packages:
 
   humanize-duration@3.33.0:
     resolution: {integrity: sha512-vYJX7BSzn7EQ4SaP2lPYVy+icHDppB6k7myNeI3wrSRfwMS5+BHyGgzpHR0ptqJ2AQ6UuIKrclSg5ve6Ci4IAQ==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -5247,6 +5255,8 @@ snapshots:
   human-signals@5.0.0: {}
 
   humanize-duration@3.33.0: {}
+
+  husky@9.1.7: {}
 
   iconv-lite@0.6.3:
     dependencies:


### PR DESCRIPTION
The pre-commit hook set currently runs formatting and linting, and type-checking before each commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a pre-commit hook to run code checks and type checks before commits, ensuring higher code quality and preventing broken commits.
  * Added Husky setup to automate the pre-commit process via a prepare script.
  * No user-facing functionality changes; this update improves development workflow and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->