### PR TITLE
refactor: modify benefits to be associated with a publication rather than a publication's plans

### DIFF
--- a/src/app/(protected)/dashboard/publication/page.tsx
+++ b/src/app/(protected)/dashboard/publication/page.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, Loader2 } from "lucide-react";
 
 import { EditPublicationForm } from "~/components/forms/edit-publication-form";
 import { OnboardingGuard } from "~/components/onboarding/onboarding-guard";
+import { PublicationBenefits } from "~/components/publication/publication-benefits";
 import { PublicationPlans } from "~/components/publication/publication-plans";
 import { PublicationShareLink } from "~/components/publication/publication-share-link";
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
@@ -108,6 +109,12 @@ function PublicationContent() {
 
         {/* Payment Plans */}
         <PublicationPlans publicationId={publication.id} />
+
+        {/* Subscriber Benefits */}
+        <PublicationBenefits
+          publicationId={publication.id}
+          publicationName={publication.name}
+        />
       </div>
     </div>
   );

--- a/src/app/publication/[slug]/page.tsx
+++ b/src/app/publication/[slug]/page.tsx
@@ -51,6 +51,20 @@ export default async function PublicationSubscriptionPage({
 
   try {
     const data = await api.publication.getBySlug({ slug });
+    const annualPlanPrice = data.plans.find(
+      (plan) => plan.interval === "annually",
+    )?.amount;
+    const monthlyPlanPrice = data.plans.find(
+      (plan) => plan.interval === "monthly",
+    )?.amount;
+
+    const savingsWithAnnual = monthlyPlanPrice
+      ? monthlyPlanPrice * 12 - (annualPlanPrice ?? 0)
+      : 0;
+
+    const percentageSaved = monthlyPlanPrice
+      ? Math.round((savingsWithAnnual / (monthlyPlanPrice * 12)) * 100)
+      : 0;
 
     return (
       <div className="min-h-screen bg-background text-foreground">
@@ -80,7 +94,7 @@ export default async function PublicationSubscriptionPage({
           {/* Plans Grid */}
           <div className="flex justify-center">
             <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-              {data.plans.map((plan, _index) => (
+              {data.plans.map((plan) => (
                 <Card key={plan.id} className="min-w-[280px] max-w-sm">
                   <CardHeader className="text-center">
                     <CardTitle className="capitalize">
@@ -100,6 +114,15 @@ export default async function PublicationSubscriptionPage({
                         <span className="text-sm">{benefit.description}</span>
                       </div>
                     ))}
+                    {plan.interval === "annually" && savingsWithAnnual > 0 && (
+                      <div className="mt-2 flex items-start gap-2">
+                        <Icons.payments className="mt-0.5 h-4 w-4 flex-shrink-0 text-yellow-500" />
+                        <span className="text-sm">
+                          Save Ksh. {savingsWithAnnual} ({percentageSaved}%){" "}
+                          compared to the monthly plan
+                        </span>
+                      </div>
+                    )}
                   </CardContent>
 
                   <CardFooter className="h-full items-end">

--- a/src/app/publication/[slug]/page.tsx
+++ b/src/app/publication/[slug]/page.tsx
@@ -94,7 +94,7 @@ export default async function PublicationSubscriptionPage({
                   </CardHeader>
 
                   <CardContent className="space-y-3">
-                    {plan.planBenefits.map((benefit) => (
+                    {data.publication.benefits.map((benefit) => (
                       <div key={benefit.id} className="flex items-start gap-2">
                         <CheckIcon className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" />
                         <span className="text-sm">{benefit.description}</span>

--- a/src/components/forms/add-benefit-form.tsx
+++ b/src/components/forms/add-benefit-form.tsx
@@ -38,15 +38,15 @@ const addBenefitSchema = z.object({
 type AddBenefitFormData = z.infer<typeof addBenefitSchema>;
 
 interface AddBenefitFormProps {
-  planId: string;
-  planName: string;
+  publicationId: string;
+  publicationName: string;
   currentBenefitCount: number;
   onSuccess?: () => void;
 }
 
 export function AddBenefitForm({
-  planId,
-  planName,
+  publicationId,
+  publicationName,
   currentBenefitCount,
   onSuccess,
 }: AddBenefitFormProps) {
@@ -60,13 +60,13 @@ export function AddBenefitForm({
     },
   });
 
-  const addBenefitMutation = api.plan.addBenefit.useMutation({
+  const addBenefitMutation = api.publication.addBenefit.useMutation({
     onSuccess: () => {
       toast.success("Benefit added successfully");
       setOpen(false);
       form.reset();
       onSuccess?.();
-      void utils.plan.getByPublication.invalidate();
+      void utils.publication.getBenefits.invalidate();
     },
     onError: (error) => {
       toast.error(error.message);
@@ -75,7 +75,7 @@ export function AddBenefitForm({
 
   const onSubmit = (data: AddBenefitFormData) => {
     addBenefitMutation.mutate({
-      planId,
+      publicationId,
       description: data.description,
     });
   };
@@ -99,9 +99,9 @@ export function AddBenefitForm({
         <DialogHeader>
           <DialogTitle>Add Benefit</DialogTitle>
           <DialogDescription>
-            Add a new benefit to {planName}
+            Add a new benefit to {publicationName}
             {isAtLimit
-              ? ` You've reached the maximum of ${MAX_BENEFITS_PER_PLAN} benefits per plan.`
+              ? ` You've reached the maximum of ${MAX_BENEFITS_PER_PLAN} benefits.`
               : ` (${currentBenefitCount}/${MAX_BENEFITS_PER_PLAN} benefits used)`}
           </DialogDescription>
         </DialogHeader>
@@ -117,7 +117,7 @@ export function AddBenefitForm({
                   <FormControl>
                     <Textarea
                       {...field}
-                      placeholder="Describe what subscribers get with this plan..."
+                      placeholder="Describe what subscribers get by subscribing to this publication..."
                       rows={3}
                       maxLength={500}
                     />

--- a/src/components/forms/clear-benefits-dialog.tsx
+++ b/src/components/forms/clear-benefits-dialog.tsx
@@ -17,27 +17,27 @@ import {
 import { api } from "~/trpc/react";
 
 interface ClearBenefitsDialogProps {
-  planId: string;
-  planName: string;
+  publicationId: string;
+  publicationName: string;
   benefitCount: number;
   onSuccess?: () => void;
 }
 
 export function ClearBenefitsDialog({
-  planId,
-  planName,
+  publicationId,
+  publicationName,
   benefitCount,
   onSuccess,
 }: ClearBenefitsDialogProps) {
   const [open, setOpen] = useState(false);
   const utils = api.useUtils();
 
-  const clearBenefitsMutation = api.plan.clearBenefits.useMutation({
+  const clearBenefitsMutation = api.publication.clearBenefits.useMutation({
     onSuccess: () => {
       toast.success("All benefits cleared successfully");
       setOpen(false);
       onSuccess?.();
-      void utils.plan.getByPublication.invalidate();
+      void utils.publication.getBenefits.invalidate();
     },
     onError: (error) => {
       toast.error(error.message);
@@ -46,7 +46,7 @@ export function ClearBenefitsDialog({
 
   const handleClear = () => {
     clearBenefitsMutation.mutate({
-      planId,
+      publicationId,
     });
   };
 
@@ -67,8 +67,8 @@ export function ClearBenefitsDialog({
           <DialogTitle>Clear All Benefits</DialogTitle>
           <DialogDescription>
             Are you sure you want to remove all {benefitCount} benefit
-            {benefitCount !== 1 ? "s" : ""} from the <strong>{planName}</strong>{" "}
-            plan? This action cannot be undone.
+            {benefitCount !== 1 ? "s" : ""} from{" "}
+            <strong>{publicationName}</strong>? This action cannot be undone.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="gap-2">

--- a/src/components/forms/delete-benefit-dialog.tsx
+++ b/src/components/forms/delete-benefit-dialog.tsx
@@ -30,12 +30,12 @@ export function DeleteBenefitDialog({
   const [open, setOpen] = useState(false);
   const utils = api.useUtils();
 
-  const deleteBenefitMutation = api.plan.deleteBenefit.useMutation({
+  const deleteBenefitMutation = api.publication.deleteBenefit.useMutation({
     onSuccess: () => {
       toast.success("Benefit deleted successfully");
       setOpen(false);
       onSuccess?.();
-      void utils.plan.getByPublication.invalidate();
+      void utils.publication.getBenefits.invalidate();
     },
     onError: (error) => {
       toast.error(error.message);

--- a/src/components/forms/edit-benefit-form.tsx
+++ b/src/components/forms/edit-benefit-form.tsx
@@ -57,12 +57,12 @@ export function EditBenefitForm({
     },
   });
 
-  const editBenefitMutation = api.plan.updateBenefit.useMutation({
+  const editBenefitMutation = api.publication.updateBenefit.useMutation({
     onSuccess: () => {
       toast.success("Benefit updated successfully");
       setOpen(false);
       onSuccess?.();
-      void utils.plan.getByPublication.invalidate();
+      void utils.publication.getBenefits.invalidate();
     },
     onError: (error) => {
       toast.error(error.message);
@@ -109,7 +109,7 @@ export function EditBenefitForm({
                   <FormControl>
                     <Textarea
                       {...field}
-                      placeholder="Describe what subscribers get with this plan..."
+                      placeholder="Describe what subscribers get with this publication..."
                       rows={3}
                       maxLength={500}
                     />

--- a/src/components/publication/publication-benefits.tsx
+++ b/src/components/publication/publication-benefits.tsx
@@ -129,7 +129,7 @@ export function PublicationBenefits({
             <AddBenefitForm
               publicationId={publicationId}
               publicationName={publicationName}
-              currentBenefitCount={0}
+              currentBenefitCount={benefits?.length ?? 0}
             />
             {benefits && benefits.length > 0 && (
               <ClearBenefitsDialog

--- a/src/components/publication/publication-benefits.tsx
+++ b/src/components/publication/publication-benefits.tsx
@@ -1,0 +1,121 @@
+import { AddBenefitForm } from "~/components/forms/add-benefit-form";
+import { ClearBenefitsDialog } from "~/components/forms/clear-benefits-dialog";
+import { DeleteBenefitDialog } from "~/components/forms/delete-benefit-dialog";
+import { EditBenefitForm } from "~/components/forms/edit-benefit-form";
+import { Badge } from "~/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card";
+import { MAX_BENEFITS_PER_PLAN } from "~/lib/constants";
+import { api } from "~/trpc/react";
+
+interface PublicationPlansProps {
+  publicationId: string;
+  publicationName: string;
+}
+
+export function PublicationBenefits({
+  publicationId,
+  publicationName,
+}: PublicationPlansProps) {
+  const {
+    data: benefits,
+    isLoading,
+    isError,
+  } = api.publication.getBenefits.useQuery({
+    publicationId,
+  });
+
+  if (isLoading) {
+    return <div>Loading benefits...</div>;
+  }
+
+  if (isError) {
+    return <div>Error loading benefits.</div>;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Publication Benefits</CardTitle>
+        <CardDescription>
+          Describe the benefits subscribers will receive with this publication.
+          You can add up to {MAX_BENEFITS_PER_PLAN} benefits.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2">
+              {benefits && benefits.length > 0 && (
+                <Badge variant="outline" className="w-fit">
+                  {benefits.length}/{MAX_BENEFITS_PER_PLAN}
+                </Badge>
+              )}
+            </div>
+
+            <div className="hidden sm:flex sm:gap-2">
+              <AddBenefitForm
+                publicationId={publicationId}
+                publicationName={publicationName}
+                currentBenefitCount={benefits?.length ?? 0}
+              />
+              {benefits && benefits.length > 0 && (
+                <ClearBenefitsDialog
+                  publicationId={publicationId}
+                  publicationName={publicationName}
+                  benefitCount={benefits.length}
+                />
+              )}
+            </div>
+          </div>
+
+          {benefits && benefits.length > 0 ? (
+            <div className="space-y-4">
+              {benefits.map((benefit) => (
+                <div
+                  key={benefit.id}
+                  className="flex items-start justify-between gap-3 rounded-md bg-muted/50 p-3"
+                >
+                  <p className="flex-1 text-sm">{benefit.description}</p>
+                  <div className="flex items-center gap-1">
+                    <EditBenefitForm
+                      benefitId={benefit.id}
+                      currentDescription={benefit.description}
+                    />
+                    <DeleteBenefitDialog
+                      benefitId={benefit.id}
+                      benefitDescription={benefit.description}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="py-4 text-center text-muted-foreground text-sm">
+              No benefits added yet.
+            </p>
+          )}
+          <div className="flex items-center justify-end gap-2 sm:hidden">
+            <AddBenefitForm
+              publicationId={publicationId}
+              publicationName={publicationName}
+              currentBenefitCount={0}
+            />
+            {benefits && benefits.length > 0 && (
+              <ClearBenefitsDialog
+                publicationId={publicationId}
+                publicationName={publicationName}
+                benefitCount={benefits.length}
+              />
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/publication/publication-benefits.tsx
+++ b/src/components/publication/publication-benefits.tsx
@@ -10,12 +10,25 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
 import { MAX_BENEFITS_PER_PLAN } from "~/lib/constants";
 import { api } from "~/trpc/react";
 
 interface PublicationPlansProps {
   publicationId: string;
   publicationName: string;
+}
+
+function Header() {
+  return (
+    <CardHeader>
+      <CardTitle>Publication Benefits</CardTitle>
+      <CardDescription>
+        Describe the benefits subscribers will receive with this publication.
+        You can add up to {MAX_BENEFITS_PER_PLAN} benefits.
+      </CardDescription>
+    </CardHeader>
+  );
 }
 
 export function PublicationBenefits({
@@ -25,28 +38,40 @@ export function PublicationBenefits({
   const {
     data: benefits,
     isLoading,
-    isError,
+    error,
   } = api.publication.getBenefits.useQuery({
     publicationId,
   });
 
   if (isLoading) {
-    return <div>Loading benefits...</div>;
+    return (
+      <Card>
+        <Header />
+        <CardContent className="space-y-4">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </CardContent>
+      </Card>
+    );
   }
 
-  if (isError) {
-    return <div>Error loading benefits.</div>;
+  if (error) {
+    return (
+      <Card>
+        <Header />
+        <CardContent>
+          <div className="py-8 text-center">
+            <p className="text-muted-foreground">Failed to load benefits</p>
+            <p className="text-muted-foreground text-sm">{error.message}</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
   }
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Publication Benefits</CardTitle>
-        <CardDescription>
-          Describe the benefits subscribers will receive with this publication.
-          You can add up to {MAX_BENEFITS_PER_PLAN} benefits.
-        </CardDescription>
-      </CardHeader>
+      <Header />
       <CardContent>
         <div className="space-y-3">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/src/components/publication/publication-benefits.tsx
+++ b/src/components/publication/publication-benefits.tsx
@@ -14,11 +14,6 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { MAX_BENEFITS_PER_PLAN } from "~/lib/constants";
 import { api } from "~/trpc/react";
 
-interface PublicationPlansProps {
-  publicationId: string;
-  publicationName: string;
-}
-
 function Header() {
   return (
     <CardHeader>
@@ -31,10 +26,15 @@ function Header() {
   );
 }
 
+interface PublicationBenefitsProps {
+  publicationId: string;
+  publicationName: string;
+}
+
 export function PublicationBenefits({
   publicationId,
   publicationName,
-}: PublicationPlansProps) {
+}: PublicationBenefitsProps) {
   const {
     data: benefits,
     isLoading,

--- a/src/components/publication/publication-plans.tsx
+++ b/src/components/publication/publication-plans.tsx
@@ -3,10 +3,6 @@
 import { ExternalLink } from "lucide-react";
 import Link from "next/link";
 
-import { AddBenefitForm } from "~/components/forms/add-benefit-form";
-import { ClearBenefitsDialog } from "~/components/forms/clear-benefits-dialog";
-import { DeleteBenefitDialog } from "~/components/forms/delete-benefit-dialog";
-import { EditBenefitForm } from "~/components/forms/edit-benefit-form";
 import { EditPlanPricingForm } from "~/components/forms/edit-plan-pricing-form";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -18,7 +14,6 @@ import {
   CardTitle,
 } from "~/components/ui/card";
 import { Skeleton } from "~/components/ui/skeleton";
-import { MAX_BENEFITS_PER_PLAN } from "~/lib/constants";
 import { api } from "~/trpc/react";
 
 interface PublicationPlansProps {
@@ -149,77 +144,6 @@ export function PublicationPlans({ publicationId }: PublicationPlansProps) {
                 </Button>
               </div>
             </div>
-
-            {/* Benefits Section */}
-            <div className="space-y-3">
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex items-center gap-2">
-                  <h5 className="font-medium text-sm">Plan Benefits</h5>
-                  {plan.planBenefits.length > 0 && (
-                    <Badge variant="outline" className="w-fit">
-                      {plan.planBenefits.length}/{MAX_BENEFITS_PER_PLAN}
-                    </Badge>
-                  )}
-                </div>
-
-                <div className="hidden sm:flex sm:gap-2">
-                  <AddBenefitForm
-                    planId={plan.id}
-                    planName={plan.name}
-                    currentBenefitCount={plan.planBenefits?.length ?? 0}
-                  />
-                  {plan.planBenefits && plan.planBenefits.length > 0 && (
-                    <ClearBenefitsDialog
-                      planId={plan.id}
-                      planName={plan.name}
-                      benefitCount={plan.planBenefits.length}
-                    />
-                  )}
-                </div>
-              </div>
-
-              {plan.planBenefits && plan.planBenefits.length > 0 ? (
-                <div className="space-y-4">
-                  {plan.planBenefits.map((benefit) => (
-                    <div
-                      key={benefit.id}
-                      className="flex items-start justify-between gap-3 rounded-md bg-muted/50 p-3"
-                    >
-                      <p className="flex-1 text-sm">{benefit.description}</p>
-                      <div className="flex items-center gap-1">
-                        <EditBenefitForm
-                          benefitId={benefit.id}
-                          currentDescription={benefit.description}
-                        />
-                        <DeleteBenefitDialog
-                          benefitId={benefit.id}
-                          benefitDescription={benefit.description}
-                        />
-                      </div>
-                    </div>
-                  ))}
-                  <div className="flex items-center justify-end gap-2 sm:hidden">
-                    <AddBenefitForm
-                      planId={plan.id}
-                      planName={plan.name}
-                      currentBenefitCount={plan.planBenefits?.length ?? 0}
-                    />
-                    {plan.planBenefits && plan.planBenefits.length > 0 && (
-                      <ClearBenefitsDialog
-                        planId={plan.id}
-                        planName={plan.name}
-                        benefitCount={plan.planBenefits.length}
-                      />
-                    )}
-                  </div>
-                </div>
-              ) : (
-                <p className="py-4 text-center text-muted-foreground text-sm">
-                  No benefits added yet. Add some benefits to describe what
-                  subscribers get with this plan.
-                </p>
-              )}
-            </div>
           </div>
         ))}
 
@@ -228,8 +152,7 @@ export function PublicationPlans({ publicationId }: PublicationPlansProps) {
             <strong>Note:</strong> Pricing changes are automatically synced with
             Paystack and will apply to new subscribers. Existing subscribers
             will continue with their current pricing until they renew their
-            subscription. Each plan can have up to {MAX_BENEFITS_PER_PLAN}{" "}
-            benefits.
+            subscription.
           </p>
         </div>
       </CardContent>

--- a/src/server/api/routers/plan.ts
+++ b/src/server/api/routers/plan.ts
@@ -272,13 +272,10 @@ export const planRouter = createTRPCRouter({
         }
 
         // Check current benefit count
-        // This includes a lock the row to prevent race conditions on concurrent benefit additions
-        // from adding more than the allowed number of benefits (with the select ... for update)
         const benefitCountResult = await tx
           .select({ count: count() })
           .from(planBenefit)
-          .where(eq(planBenefit.planId, input.planId))
-          .for("update");
+          .where(eq(planBenefit.planId, input.planId));
 
         const benefitCount = benefitCountResult[0]?.count ?? 0;
 

--- a/src/server/api/routers/plan.ts
+++ b/src/server/api/routers/plan.ts
@@ -1,12 +1,11 @@
 import { TRPCError } from "@trpc/server";
-import { count, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import z from "zod";
 
-import { MAX_BENEFITS_PER_PLAN } from "~/lib/constants";
 import { getCreator } from "~/server/actions/trpc/creator";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import type { DbType } from "~/server/db";
-import { plan, planBenefit, publication } from "~/server/db/schema/app-schema";
+import { plan, publication } from "~/server/db/schema/app-schema";
 import {
   type createPaymentPageSchema,
   type createPlanSchema,
@@ -26,30 +25,6 @@ const CreatePlanInfoSchema = z.object({
 const UpdatePlanInfoSchema = z.object({
   planId: z.uuid("Invalid plan ID"),
   amount: z.number().min(100, "Amount must be at least Ksh. 100"),
-});
-
-const AddBenefitSchema = z.object({
-  planId: z.uuid("Invalid plan ID"),
-  description: z
-    .string()
-    .min(1, "Benefit description is required")
-    .max(500, "Benefit description must be less than 500 characters"),
-});
-
-const UpdateBenefitSchema = z.object({
-  benefitId: z.uuid("Invalid benefit ID"),
-  description: z
-    .string()
-    .min(1, "Benefit description is required")
-    .max(500, "Benefit description must be less than 500 characters"),
-});
-
-const DeleteBenefitSchema = z.object({
-  benefitId: z.uuid("Invalid benefit ID"),
-});
-
-const ClearBenefitsSchema = z.object({
-  planId: z.uuid("Invalid plan ID"),
 });
 
 type CreatePaystackPlanInfo = z.infer<typeof createPlanSchema>;
@@ -166,11 +141,6 @@ export const planRouter = createTRPCRouter({
       const plans = await ctx.db.query.plan.findMany({
         where: eq(plan.publicationId, input.publicationId),
         orderBy: plan.interval,
-        with: {
-          planBenefits: {
-            orderBy: planBenefit.createdAt,
-          },
-        },
       });
 
       return plans;
@@ -237,190 +207,6 @@ export const planRouter = createTRPCRouter({
         console.log(
           "Plan updated successfully on both Paystack and local database",
         );
-        return { success: true };
-      });
-    }),
-
-  /** Add a benefit to a plan (max 4 benefits per plan) */
-  addBenefit: protectedProcedure
-    .input(AddBenefitSchema)
-    .mutation(async ({ ctx, input }) => {
-      return await ctx.db.transaction(async (tx) => {
-        const foundCreator = await getCreator(tx, ctx.session.user.id);
-
-        // Get the plan and verify ownership
-        const foundPlan = await tx.query.plan.findFirst({
-          where: eq(plan.id, input.planId),
-          with: {
-            publication: true,
-          },
-        });
-
-        if (!foundPlan) {
-          throw new TRPCError({
-            message: "Plan not found",
-            code: "NOT_FOUND",
-          });
-        }
-
-        // Verify the plan's publication belongs to this creator
-        if (foundPlan.publication.creatorId !== foundCreator.id) {
-          throw new TRPCError({
-            message: "You don't have permission to edit this plan",
-            code: "FORBIDDEN",
-          });
-        }
-
-        // Check current benefit count
-        const benefitCountResult = await tx
-          .select({ count: count() })
-          .from(planBenefit)
-          .where(eq(planBenefit.planId, input.planId));
-
-        const benefitCount = benefitCountResult[0]?.count ?? 0;
-
-        if (benefitCount >= MAX_BENEFITS_PER_PLAN) {
-          throw new TRPCError({
-            message: `A plan can have a maximum of ${MAX_BENEFITS_PER_PLAN} benefits`,
-            code: "BAD_REQUEST",
-          });
-        }
-
-        // Add the benefit
-        const result = await tx
-          .insert(planBenefit)
-          .values({
-            planId: input.planId,
-            description: input.description,
-          })
-          .returning();
-
-        return result[0];
-      });
-    }),
-
-  /** Update a benefit description */
-  updateBenefit: protectedProcedure
-    .input(UpdateBenefitSchema)
-    .mutation(async ({ ctx, input }) => {
-      return await ctx.db.transaction(async (tx) => {
-        const foundCreator = await getCreator(tx, ctx.session.user.id);
-
-        // Get the benefit and verify ownership through plan
-        const foundBenefit = await tx.query.planBenefit.findFirst({
-          where: eq(planBenefit.id, input.benefitId),
-          with: {
-            plan: {
-              with: {
-                publication: true,
-              },
-            },
-          },
-        });
-
-        if (!foundBenefit) {
-          throw new TRPCError({
-            message: "Benefit not found",
-            code: "NOT_FOUND",
-          });
-        }
-
-        // Verify ownership
-        if (foundBenefit.plan.publication.creatorId !== foundCreator.id) {
-          throw new TRPCError({
-            message: "You don't have permission to edit this benefit",
-            code: "FORBIDDEN",
-          });
-        }
-
-        // Update the benefit
-        await tx
-          .update(planBenefit)
-          .set({
-            description: input.description,
-          })
-          .where(eq(planBenefit.id, input.benefitId));
-
-        return { success: true };
-      });
-    }),
-
-  /** Delete a benefit */
-  deleteBenefit: protectedProcedure
-    .input(DeleteBenefitSchema)
-    .mutation(async ({ ctx, input }) => {
-      return await ctx.db.transaction(async (tx) => {
-        const foundCreator = await getCreator(tx, ctx.session.user.id);
-
-        // Get the benefit and verify ownership through plan
-        const foundBenefit = await tx.query.planBenefit.findFirst({
-          where: eq(planBenefit.id, input.benefitId),
-          with: {
-            plan: {
-              with: {
-                publication: true,
-              },
-            },
-          },
-        });
-
-        if (!foundBenefit) {
-          throw new TRPCError({
-            message: "Benefit not found",
-            code: "NOT_FOUND",
-          });
-        }
-
-        // Verify ownership
-        if (foundBenefit.plan.publication.creatorId !== foundCreator.id) {
-          throw new TRPCError({
-            message: "You don't have permission to delete this benefit",
-            code: "FORBIDDEN",
-          });
-        }
-
-        // Delete the benefit
-        await tx.delete(planBenefit).where(eq(planBenefit.id, input.benefitId));
-
-        return { success: true };
-      });
-    }),
-
-  /** Clear all benefits for a plan */
-  clearBenefits: protectedProcedure
-    .input(ClearBenefitsSchema)
-    .mutation(async ({ ctx, input }) => {
-      return await ctx.db.transaction(async (tx) => {
-        const foundCreator = await getCreator(tx, ctx.session.user.id);
-
-        // Get the plan and verify ownership
-        const foundPlan = await tx.query.plan.findFirst({
-          where: eq(plan.id, input.planId),
-          with: {
-            publication: true,
-          },
-        });
-
-        if (!foundPlan) {
-          throw new TRPCError({
-            message: "Plan not found",
-            code: "NOT_FOUND",
-          });
-        }
-
-        // Verify the plan's publication belongs to this creator
-        if (foundPlan.publication.creatorId !== foundCreator.id) {
-          throw new TRPCError({
-            message: "You don't have permission to edit this plan",
-            code: "FORBIDDEN",
-          });
-        }
-
-        // Delete all benefits for this plan
-        await tx
-          .delete(planBenefit)
-          .where(eq(planBenefit.planId, input.planId));
-
         return { success: true };
       });
     }),

--- a/src/server/api/routers/publication.ts
+++ b/src/server/api/routers/publication.ts
@@ -1,7 +1,8 @@
 import { TRPCError } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, count, eq } from "drizzle-orm";
 import z from "zod";
 
+import { MAX_BENEFITS_PER_PLAN } from "~/lib/constants";
 import { generateSlugFromName } from "~/lib/utils";
 import { getCreator } from "~/server/actions/trpc/creator";
 import {
@@ -12,7 +13,12 @@ import {
 import { decryptSecret } from "~/server/crypto/kit-secrets";
 import type { DbType } from "~/server/db";
 import { user } from "~/server/db/schema";
-import { creator, plan, publication } from "~/server/db/schema/app-schema";
+import {
+  creator,
+  plan,
+  publication,
+  publicationBenefit,
+} from "~/server/db/schema/app-schema";
 import { kitClient } from "~/server/fetch-clients/kit";
 
 const CreatePublicationInfoSchema = z.object({
@@ -46,6 +52,30 @@ const UpdatePublicationInfoSchema = z.object({
     .refine((slug) => !slug.includes("--"), {
       message: "Slug cannot contain consecutive hyphens",
     }),
+});
+
+const AddBenefitSchema = z.object({
+  publicationId: z.uuid("Invalid publication ID"),
+  description: z
+    .string()
+    .min(1, "Benefit description is required")
+    .max(500, "Benefit description must be less than 500 characters"),
+});
+
+const UpdateBenefitSchema = z.object({
+  benefitId: z.uuid("Invalid benefit ID"),
+  description: z
+    .string()
+    .min(1, "Benefit description is required")
+    .max(500, "Benefit description must be less than 500 characters"),
+});
+
+const DeleteBenefitSchema = z.object({
+  benefitId: z.uuid("Invalid benefit ID"),
+});
+
+const ClearBenefitsSchema = z.object({
+  publicationId: z.uuid("Invalid publication ID"),
 });
 
 // TODO: Use one validation schema on front and back end
@@ -260,11 +290,6 @@ export const publicationRouter = createTRPCRouter({
           amount: true,
           paystackPaymentPageUrlSlug: true,
         },
-        with: {
-          planBenefits: {
-            columns: { id: true, description: true },
-          },
-        },
       });
 
       if (plans.length === 0) {
@@ -284,6 +309,205 @@ export const publicationRouter = createTRPCRouter({
         },
         plans,
       };
+    }),
+
+  getBenefits: protectedProcedure
+    .input(z.object({ publicationId: z.uuid("Invalid publication ID") }))
+    .query(async ({ ctx, input }) => {
+      const foundCreator = await getCreator(ctx.db, ctx.session.user.id);
+
+      // Verify the publication belongs to this creator
+      const publicationResult = await ctx.db.query.publication.findFirst({
+        where: eq(publication.id, input.publicationId),
+      });
+
+      if (
+        !publicationResult ||
+        publicationResult.creatorId !== foundCreator.id
+      ) {
+        throw new TRPCError({
+          message: "Publication not found or access denied",
+          code: "NOT_FOUND",
+        });
+      }
+
+      const benefits = await ctx.db.query.publicationBenefit.findMany({
+        where: eq(publicationBenefit.publicationId, input.publicationId),
+        orderBy: publicationBenefit.createdAt,
+      });
+
+      return benefits;
+    }),
+  /** Add a benefit to a plan (max 4 benefits per plan) */
+  addBenefit: protectedProcedure
+    .input(AddBenefitSchema)
+    .mutation(async ({ ctx, input }) => {
+      return await ctx.db.transaction(async (tx) => {
+        const foundCreator = await getCreator(tx, ctx.session.user.id);
+
+        // Get publication and verify ownership
+        const foundPublication = await tx.query.publication.findFirst({
+          where: eq(publication.id, input.publicationId),
+        });
+
+        if (!foundPublication) {
+          throw new TRPCError({
+            message: "Publication not found",
+            code: "NOT_FOUND",
+          });
+        }
+
+        // Verify the publication belongs to this creator
+        if (foundPublication.creatorId !== foundCreator.id) {
+          throw new TRPCError({
+            message: "You don't have permission to edit this publication",
+            code: "FORBIDDEN",
+          });
+        }
+
+        // Check current benefit count
+        const benefitCountResult = await tx
+          .select({ count: count() })
+          .from(publicationBenefit)
+          .where(eq(publicationBenefit.publicationId, input.publicationId));
+
+        const benefitCount = benefitCountResult[0]?.count ?? 0;
+
+        if (benefitCount >= MAX_BENEFITS_PER_PLAN) {
+          throw new TRPCError({
+            message: `A publication can have a maximum of ${MAX_BENEFITS_PER_PLAN} benefits`,
+            code: "BAD_REQUEST",
+          });
+        }
+
+        // Add the benefit
+        const result = await tx
+          .insert(publicationBenefit)
+          .values({
+            publicationId: input.publicationId,
+            description: input.description,
+          })
+          .returning();
+
+        return result[0];
+      });
+    }),
+
+  /** Update a benefit description */
+  updateBenefit: protectedProcedure
+    .input(UpdateBenefitSchema)
+    .mutation(async ({ ctx, input }) => {
+      return await ctx.db.transaction(async (tx) => {
+        const foundCreator = await getCreator(tx, ctx.session.user.id);
+
+        // Get the benefit and verify ownership through publication
+        const foundBenefit = await tx.query.publicationBenefit.findFirst({
+          where: eq(publicationBenefit.id, input.benefitId),
+          with: {
+            publication: true,
+          },
+        });
+
+        if (!foundBenefit) {
+          throw new TRPCError({
+            message: "Benefit not found",
+            code: "NOT_FOUND",
+          });
+        }
+
+        // Verify ownership
+        if (foundBenefit.publication.creatorId !== foundCreator.id) {
+          throw new TRPCError({
+            message: "You don't have permission to edit this benefit",
+            code: "FORBIDDEN",
+          });
+        }
+
+        // Update the benefit
+        await tx
+          .update(publicationBenefit)
+          .set({
+            description: input.description,
+          })
+          .where(eq(publicationBenefit.id, input.benefitId));
+
+        return { success: true };
+      });
+    }),
+
+  /** Delete a benefit */
+  deleteBenefit: protectedProcedure
+    .input(DeleteBenefitSchema)
+    .mutation(async ({ ctx, input }) => {
+      return await ctx.db.transaction(async (tx) => {
+        const foundCreator = await getCreator(tx, ctx.session.user.id);
+
+        // Get the benefit and verify ownership through publication
+        const foundBenefit = await tx.query.publicationBenefit.findFirst({
+          where: eq(publicationBenefit.id, input.benefitId),
+          with: {
+            publication: true,
+          },
+        });
+
+        if (!foundBenefit) {
+          throw new TRPCError({
+            message: "Benefit not found",
+            code: "NOT_FOUND",
+          });
+        }
+
+        // Verify ownership
+        if (foundBenefit.publication.creatorId !== foundCreator.id) {
+          throw new TRPCError({
+            message: "You don't have permission to delete this benefit",
+            code: "FORBIDDEN",
+          });
+        }
+
+        // Delete the benefit
+        await tx
+          .delete(publicationBenefit)
+          .where(eq(publicationBenefit.id, input.benefitId));
+
+        return { success: true };
+      });
+    }),
+
+  /** Clear all benefits for a plan */
+  clearBenefits: protectedProcedure
+    .input(ClearBenefitsSchema)
+    .mutation(async ({ ctx, input }) => {
+      return await ctx.db.transaction(async (tx) => {
+        const foundCreator = await getCreator(tx, ctx.session.user.id);
+
+        // Get publication and verify ownership
+        const foundPublication = await tx.query.publication.findFirst({
+          where: eq(publication.id, input.publicationId),
+        });
+
+        if (!foundPublication) {
+          throw new TRPCError({
+            message: "Publication not found",
+            code: "NOT_FOUND",
+          });
+        }
+
+        // Verify the publication belongs to this creator
+        if (foundPublication.creatorId !== foundCreator.id) {
+          throw new TRPCError({
+            message: "You don't have permission to edit this publication",
+            code: "FORBIDDEN",
+          });
+        }
+
+        // Delete all benefits for this plan
+        await tx
+          .delete(publicationBenefit)
+          .where(eq(publicationBenefit.publicationId, input.publicationId));
+
+        return { success: true };
+      });
     }),
 });
 

--- a/src/server/api/routers/publication.ts
+++ b/src/server/api/routers/publication.ts
@@ -248,6 +248,9 @@ export const publicationRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const foundPublication = await ctx.db.query.publication.findFirst({
         where: eq(publication.slug, input.slug),
+        with: {
+          benefits: true,
+        },
       });
 
       if (!foundPublication) {
@@ -304,6 +307,7 @@ export const publicationRouter = createTRPCRouter({
         publication: {
           name: foundPublication.name,
           description: foundPublication.description,
+          benefits: foundPublication.benefits,
           slug: foundPublication.slug,
           createdAt: foundPublication.createdAt,
         },

--- a/src/server/db/schema/app-schema.ts
+++ b/src/server/db/schema/app-schema.ts
@@ -115,6 +115,15 @@ export const publicationBenefit = createTable("publication_benefit", (d) => ({
   updatedAt,
 }));
 
+export const publicationRelations = relations(publication, ({ many, one }) => ({
+  plans: many(plan),
+  benefits: many(publicationBenefit),
+  creator: one(creator, {
+    fields: [publication.creatorId],
+    references: [creator.id],
+  }),
+}));
+
 export const planRelations = relations(plan, ({ one }) => ({
   publication: one(publication, {
     fields: [plan.publicationId],

--- a/src/server/db/schema/app-schema.ts
+++ b/src/server/db/schema/app-schema.ts
@@ -104,28 +104,30 @@ export const plan = createTable(
   ],
 );
 
-export const planBenefit = createTable("plan_benefit", (d) => ({
+export const publicationBenefit = createTable("publication_benefit", (d) => ({
   id: d.uuid().primaryKey().defaultRandom(),
-  planId: d
+  publicationId: d
     .uuid()
     .notNull()
-    .references(() => plan.id, { onDelete: "cascade" }),
+    .references(() => publication.id, { onDelete: "cascade" }),
   description: d.text().notNull(),
   createdAt,
   updatedAt,
 }));
 
-export const planRelations = relations(plan, ({ many, one }) => ({
-  planBenefits: many(planBenefit),
+export const planRelations = relations(plan, ({ one }) => ({
   publication: one(publication, {
     fields: [plan.publicationId],
     references: [publication.id],
   }),
 }));
 
-export const planBenefitRelations = relations(planBenefit, ({ one }) => ({
-  plan: one(plan, {
-    fields: [planBenefit.planId],
-    references: [plan.id],
+export const publicationBenefitRelations = relations(
+  publicationBenefit,
+  ({ one }) => ({
+    publication: one(publication, {
+      fields: [publicationBenefit.publicationId],
+      references: [publication.id],
+    }),
   }),
-}));
+);


### PR DESCRIPTION
A design decision was made where benefits should be shared across plans, with the difference between plans being restricted to only the interval in which the subscription is paid over, and whether the annual plan offers savings over the monthly plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Subscriber Benefits section to publication settings with add, edit, delete, and clear actions.
  - Publication pages now show publication-level benefits alongside plans.
  - Annual plan savings (amount and percentage) are calculated and displayed.
  - New page header and footer for improved presentation.

- UI/UX
  - Responsive benefits management with loading/error states and count badges.
  - Streamlined plans display using composable cards.

- Refactor
  - Benefits moved from plan-level to publication-level for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->