### PR TITLE
docs(audit): record failing Trigger.dev prod deploy

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -17,6 +17,11 @@ Findings are ordered by severity. Anything not directly proven is marked "unveri
 
 ## HIGH
 
+### H0. Trigger.dev production deploys are broken: "Project not found"
+`.github/workflows/release-trigger-prod.yml` — the deploy on the July 2026 merge failed with `Project not found: proj_ylfntikuurvooheskvbe` (run 29347541617). The workflow last succeeded 2025-12-14; nothing in the repo changed the project ref (`trigger.config.ts`), so the Trigger.dev-side project or the `TRIGGER_ACCESS_TOKEN` secret has likely been deleted/rotated/rescoped in the meantime. Until fixed, scheduled/background jobs run the December 2025 task code.
+**Fix:** verify the project ref in the Trigger.dev dashboard and re-issue/update the `TRIGGER_ACCESS_TOKEN` repo secret, then re-run the workflow.
+
+
 ### H1. Renewal-payment webhooks are deduplicated by subscription code only — renewals get silently dropped
 `src/app/api/webhooks/paystack/events/payment.ts:195-197` (`paystack-invoice-payment-success-${data.subscription.subscription_code}`) and `payment.ts:148-150` (failed-payment variant). The Trigger.dev idempotency key contains no invoice/reference component, so **every renewal of the same subscription produces the same key**. Within the idempotency-key TTL (Trigger.dev default 30 days) the second `invoice.update` is treated as a duplicate and never processed: `totalRevenue` and `nextPaymentDate` are not updated. Guaranteed loss for the daily/hourly (test) intervals; monthly renewals sit right at the 30-day TTL boundary. Compare the one-time-payment key, which correctly uses the payment `reference` (`payment.ts:73-75`).
 **Fix:** include a per-invoice discriminator in the key, e.g. `...-${subscription_code}-${data.id ?? data.reference}` (same for the failed-payment key).


### PR DESCRIPTION
The Deploy to Trigger.dev (prod) workflow fails with `Project not found: proj_ylfntikuurvooheskvbe` (last success 2025-12-14). Documented as AUDIT.md H0 — needs a dashboard-side check of the project ref and the `TRIGGER_ACCESS_TOKEN` secret.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/msplke/codesmith/goldroad/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->