### PR TITLE
chore: adopt shared renovate-config preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "customManagers:biomeVersions"],
-  "rangeStrategy": "bump",
-  "automerge": false
+  "extends": [
+    "github>peterkibuchi/renovate-config",
+    "customManagers:biomeVersions"
+  ]
 }


### PR DESCRIPTION
Swaps local Renovate policy for the shared preset (github>peterkibuchi/renovate-config). Repo-specific rules preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/msplke/codesmith/goldroad/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->